### PR TITLE
Add `nth` function to Seq

### DIFF
--- a/src/Seq.elm
+++ b/src/Seq.elm
@@ -153,7 +153,8 @@ headAndTail list =
 {-| Get the nth element of a list.
 -}
 nth : Int -> Seq a -> Maybe a
-nth = ((<<) head) << drop << (+) (-1)
+nth n list =
+    head <| drop (n-1) list
 
 
 {-| Test if a value is a member of a list.

--- a/src/Seq.elm
+++ b/src/Seq.elm
@@ -1,7 +1,7 @@
 module Seq exposing
     ( Seq(..)
     , cons, empty, singleton
-    , isEmpty, head, tail, headAndTail, member, length
+    , isEmpty, head, tail, headAndTail, nth, member, length
     , toList, fromList, toArray, fromArray
     , map, zip, reduce, reductions, flatten, append, foldl, foldr
     , intersperse, interleave, reverse, cycle, iterate, repeat, take, takeWhile, drop, dropWhile
@@ -27,7 +27,7 @@ module Seq exposing
 
 # Query operations.
 
-@docs isEmpty, head, tail, headAndTail, member, length
+@docs isEmpty, head, tail, headAndTail, nth, member, length
 
 
 # Conversions.
@@ -148,6 +148,12 @@ headAndTail list =
 
         Cons first rest ->
             Just ( first, rest () )
+
+
+{-| Get the nth element of a list.
+-}
+nth : Int -> Seq a -> Maybe a
+nth = ((<<) head) << drop << (+) (-1)
 
 
 {-| Test if a value is a member of a list.


### PR DESCRIPTION
I found your library to be the most convenient for lazy lists out of the rest, but I quickly found myself in need of an `nth` function multiple times. Maybe that would be the case for others as well.
Would this be a welcomed addition?
I look forward to your response.